### PR TITLE
Fix to get curator name from file.

### DIFF
--- a/src/proforma/proforma_operations.py
+++ b/src/proforma/proforma_operations.py
@@ -226,7 +226,7 @@ class ProformaFile(object):
 
         cam_pattern = r"""
             ^            # match from the start
-            (\w+)        # The user initials
+            (\D+)        # The user initials
             \d+          # string of integers
             \.           # a dot
             (\w+)        # type of proforma


### PR DESCRIPTION
Currently we do not pass any cambridge files through the new python parser. Having tried it just for the sake of it and to see how many problems we might have I gave it a go. This is the first problem.