### PR TITLE
Transposon fake

### DIFF
--- a/src/chado_object/__init__.py
+++ b/src/chado_object/__init__.py
@@ -11,3 +11,4 @@ from .chado_div import ChadoDiv
 from .chado_exceptions import ValidationError
 from .general.chado_grp import ChadoGrp
 from .seqfeat.chado_seqfeat import ChadoSeqFeat
+from .chado_transposon import ChadoTransposon

--- a/src/chado_object/allele/chado_allele.py
+++ b/src/chado_object/allele/chado_allele.py
@@ -64,7 +64,8 @@ class ChadoAllele(ChadoFeatureObject):
                           'libraryfeatureprop': self.load_lfp,
                           'rename': self.rename,
                           'dis_pub': self.dis_pub,
-                          'make_obsolete': self.make_obsolete}
+                          'make_obsolete': self.make_obsolete,
+                          'notdone': self.not_done}
         self.delete_dict = {'featureprop': self.delete_featureprop,
                             'GA12a_featureprop': self.GA12a_featureprop_delete,
                             'synonym': self.delete_synonym,
@@ -89,6 +90,11 @@ class ChadoAllele(ChadoFeatureObject):
         self.process_data = self.load_reference_yaml(yml_file, params)
         # self.genus = "Drosophila"
         # self.species = "melanogaster"
+
+    def not_done(self, key):
+        # Remove once GA35 done.
+        # Will be done once transposon have been sorted out.
+        self.critical_error(self.process_data['GA35']['data'], "Not programmed yet")
 
     def checks(self, references):  # noqa
         """Check for Allele required data.

--- a/src/chado_object/chado_transposon.py
+++ b/src/chado_object/chado_transposon.py
@@ -1,0 +1,18 @@
+import logging
+from chado_object.feature.chado_feature import ChadoFeatureObject
+
+log = logging.getLogger(__name__)
+
+
+class ChadoTransposon(ChadoFeatureObject):
+
+    def __init__(self, params):
+        """Initialise the chado object."""
+        log.debug('No Transposon coded yet object.')
+
+        # Initiate the parent.
+        super(ChadoTransposon, self).__init__(params)
+
+    def load_content(self, references):
+        log.warning("Transposon NOT coded yet")
+        return None

--- a/src/chado_object/conversions/proforma/process_data_input.py
+++ b/src/chado_object/conversions/proforma/process_data_input.py
@@ -19,6 +19,7 @@ from chado_object.chado_db import ChadoDb
 from chado_object.general.chado_grp import ChadoGrp
 from chado_object.general.chado_cell_line import ChadoCellLine
 from chado_object.seqfeat.chado_seqfeat import ChadoSeqFeat
+from chado_object.chado_transposon import ChadoTransposon
 
 import logging
 import sys
@@ -104,6 +105,7 @@ def process_data_input(proforma_object):
         'DATABASE': (ChadoDb),
         'SEQUENCE': (ChadoSeqFeat),
         'CULTURED': (ChadoCellLine),
+        'TRANSPOSON': (ChadoTransposon),
     }
 
     try:

--- a/src/chado_object/yml/allele.yml
+++ b/src/chado_object/yml/allele.yml
@@ -280,6 +280,8 @@ GA34c:
     cv: property type
     cvterm: hdm_internal_notes
     value: GA34c
+GA35:
+    type: notdone
 # 'GA36', 'disease_associated',    #cv property type -- featureprop y/blank
 GA36:
     type: featureprop

--- a/src/chado_object/yml/transposon.yml
+++ b/src/chado_object/yml/transposon.yml
@@ -1,0 +1,151 @@
+
+# ! MA1f. Database ID for insertion (FBti) :
+MA1f:
+  type: ignore
+# ! MA1a. Insertion symbol to use in database :
+MA1a:
+  type: ignore
+# ! MA1b. Symbol used in reference :
+MA1b:
+  type: ignore
+# ! MA27. Insertion category [CV] :
+MA27:
+  type: ignore
+# ! MA4. Symbol of inserted transposon :
+MA4:
+  type: ignore
+# ! MA20. Species of host genome :
+MA20:
+  type: ignore
+# ! MA1c. Action - rename this insertion symbol :
+MA1c:
+  type: ignore
+# ! MA1g. Action - merge these insertion(s) (FBti) :
+MA1g:
+  type: ignore
+# ! MA1h. Action - delete insertion record (“y”/blank) :
+MA1h:
+  type: ignore
+# ! MA1i. Action - dissociate MA1f from FBrf (“y”/blank) :
+MA1i:
+  type: ignore
+# ! MA1d. Other synonym(s) for insertion symbol :
+MA1d:
+  type: ignore
+# ! MA1e. Silent synonym(s) for insertion symbol :
+MA1e:
+  type: ignore
+# ! MA22. Line id associated with insertion :
+MA22:
+  type: ignore
+# ! MA5a. Chromosomal location of insert :
+MA5a:
+  type: ignore
+# ! MA5c. Cytological location of insert (in situ) :
+MA5c:
+  type: ignore
+# ! MA5e. Cytological location (inferred from sequence) :
+MA5e:
+  type: ignore
+# ! MA5f. Genomic release number for data reported in MA5e :
+MA5f:
+  type: ignore
+# ! MA5d. Insertion maps to/near gene :
+MA5d:
+  type: ignore
+# ! MA7. Associated chromosomal aberration :
+MA7:
+  type: ignore
+# ! MA14. Associated balancer :
+MA14:
+  type: ignore
+# ! MA12. Consequent allele(s) :
+MA12:
+  type: ignore
+# ! MA8. Phenotype (viable, fertile) :
+MA8:
+  type: ignore
+# ! MA21a. Genomic location of insertion :
+MA21a:
+  type: ignore
+# ! MA21b. Genome release number for entry in MA21a :
+MA21b:
+  type: ignore
+# ! MA21e. Comments concerning genomic location :
+MA21e:
+  type: ignore
+# ! MA6. Orientation of insert relative to chromosome :
+MA6:
+  type: ignore
+# ! MA21c. Insertion into natTE (identified, in FB) :
+MA21c:
+  type: ignore
+# ! MA21f. Insertion into other TE or repeat region (“y”/blank) :
+MA21f:
+  type: ignore
+# ! MA21d. Distance from insertion site to end of natTE/repeat :
+MA21d:
+  type: ignore
+# ! MA19a. Accession for insertion flanking sequence (dupl for multiple) :
+MA19a:
+  type: ignore
+# ! MA19b. Insertion site accession type (5’, 3’, b) :
+MA19b:
+  type: ignore
+# ! MA19c. Position of first base of target sequence in accession :
+MA19c:
+  type: ignore
+# ! MA19d. First base of unique sequence in accession if in natTE :
+MA19d:
+  type: ignore
+# ! MA19e. Accession invalidation or assessment :
+MA19e:
+  type: ignore
+# ! MA26. Accession for this instance of natTE :
+MA26:
+  type: ignore
+# ! MA23a. Insertion-affected gene reported (dupl for multiple) :
+MA23a:
+  type: ignore
+# ! MA23b. Affected gene criteria [CV] :
+MA23b:
+  type: ignore
+# ! MA23c. Comment, affected gene criteria [free text] :
+MA23c:
+  type: ignore
+# ! MA23g. Orientation relative to affected gene :
+MA23g:
+  type: ignore
+# ! MA15a. FBti progenitor (via transposition) at distinct location :
+MA15a:
+  type: ignore
+# ! MA15b. FBti progenitor (via recombination) at distinct location :
+MA15b:
+  type: ignore
+# ! MA15c. Replaced FBti progenitor, recombination substrate :
+MA15c:
+  type: ignore
+# ! MA15d. Modified FBti progenitor (in situ) :
+MA15d:
+  type: ignore
+# ! MA24. Arose in multiple insertion line (“y”/“p”/blank) :
+MA24:
+  type: ignore
+# ! MA18. Co-isolated insertion(s) :
+MA18:
+  type: ignore
+# ! MA9. Comments [free text] :
+MA9:
+  type: ignore
+# ! MA16. Information on availability :
+MA16:
+  type: ignore
+# ! MA30. From dataset/collection (symbol) :
+MA30:
+  type: ignore
+# ! MA30a. Type of relationship to dataset/collection [member_of_reagent_collection/experimental_result] :
+MA30a:
+  type: ignore
+# ! MA10. Internal notes :
+MA10:
+  type: ignore

--- a/src/validation/validation_operations.py
+++ b/src/validation/validation_operations.py
@@ -98,6 +98,11 @@ def get_validate_cell_line_schema(fields_values):
     return "cell_line.yaml"
 
 
+def get_validate_transposon_schema(fields_values):
+    log.critical("TRANSPOSON Not coded yet.")
+    return "transposon.yaml"
+
+
 def validation_file_schema_lookup(proforma_type, fields_values):
     """Lookup the file schema.
 
@@ -129,7 +134,8 @@ def validation_file_schema_lookup(proforma_type, fields_values):
                        "SPECIES": get_validate_species_schema,
                        "GENEGROUP": get_validate_grp_schema,
                        "SEQUENCE": get_validate_seqfeat_schema,
-                       "CULTURED": get_validate_cell_line_schema}
+                       "CULTURED": get_validate_cell_line_schema,
+                       "TRANSPOSON": get_validate_transposon_schema}
     # if we have specific validation stuff set it up here.
     validation_base = {"PUBLICATION": ValidatorPub,
                        "MULTIPUBLICATION": ValidatorMultipub,
@@ -143,7 +149,8 @@ def validation_file_schema_lookup(proforma_type, fields_values):
                        "SPECIES": ValidatorBase,
                        "SEQUENCE": ValidatorBase,
                        "GENEGROUP": ValidatorBase,
-                       "CULTURED": ValidatorBase}
+                       "CULTURED": ValidatorBase,
+                       "TRANSPOSON": ValidatorBase}
     validator = None
 
     pattern = r"""

--- a/src/validation/yaml/allele.yaml
+++ b/src/validation/yaml/allele.yaml
@@ -236,6 +236,11 @@ GA34c:
     required: False
     nullable: True
     at_forbidden: True
+GA35:  # Not programmed yet
+    type: [list, string]
+    required: False
+    nullable: True
+    at_forgiven: True
 GA36:
     type: string
     required: False

--- a/src/validation/yaml/allele.yaml
+++ b/src/validation/yaml/allele.yaml
@@ -240,7 +240,7 @@ GA35:  # Not programmed yet
     type: [list, string]
     required: False
     nullable: True
-    at_forgiven: True
+    at_forbidden: True
 GA36:
     type: string
     required: False

--- a/src/validation/yaml/publication.yaml
+++ b/src/validation/yaml/publication.yaml
@@ -179,7 +179,8 @@ P41:
     cell_line, cell_line::DONE,
     cell_line(commercial), cell_line(commercial)::DONE,
     cell_line(stable), cell_line(stable)::DONE,
-    chemical, chemical::DONE]
+    chemical, chemical::DONE,
+    no_flag]
 P42:
   required: False
   nullable: True

--- a/src/validation/yaml/transposon.yaml
+++ b/src/validation/yaml/transposon.yaml
@@ -1,0 +1,250 @@
+# ! MA1f. Database ID for insertion (FBti) :
+MA1f:
+  required: False
+  nullable: True
+  type: string
+# ! MA1a. Insertion symbol to use in database :
+MA1a:
+  required: False
+  nullable: True
+  type: string
+# ! MA1b. Symbol used in reference :
+MA1b:
+  required: False
+  nullable: True
+  type: string
+# ! MA27. Insertion category [CV] :
+MA27:
+  required: False
+  nullable: True
+  type: string
+# ! MA4. Symbol of inserted transposon :
+MA4:
+  required: False
+  nullable: True
+  type: string
+# ! MA20. Species of host genome :
+MA20:
+  required: False
+  nullable: True
+  type: string
+# ! MA1c. Action - rename this insertion symbol :
+MA1c:
+  required: False
+  nullable: True
+  type: string
+# ! MA1g. Action - merge these insertion(s) (FBti) :
+MA1g:
+  required: False
+  nullable: True
+  type: [list, string]
+# ! MA1h. Action - delete insertion record (“y”/blank) :
+MA1h:
+  required: False
+  nullable: True
+  type: string
+# ! MA1i. Action - dissociate MA1f from FBrf (“y”/blank) :
+MA1i:
+  required: False
+  nullable: True
+  type: string
+# ! MA1d. Other synonym(s) for insertion symbol :
+MA1d:
+  required: False
+  nullable: True
+  type: string
+# ! MA1e. Silent synonym(s) for insertion symbol :
+MA1e:
+  required: False
+  nullable: True
+  type: string
+# ! MA22. Line id associated with insertion :
+MA22:
+  required: False
+  nullable: True
+  type: string
+# ! MA5a. Chromosomal location of insert :
+MA5a:
+  required: False
+  nullable: True
+  type: string
+# ! MA5c. Cytological location of insert (in situ) :
+MA5c:
+  required: False
+  nullable: True
+  type: string
+# ! MA5e. Cytological location (inferred from sequence) :
+MA5e:
+  required: False
+  nullable: True
+  type: string
+# ! MA5f. Genomic release number for data reported in MA5e :
+MA5f:
+  required: False
+  nullable: True
+  type: string
+# ! MA5d. Insertion maps to/near gene :
+MA5d:
+  required: False
+  nullable: True
+  type: string
+# ! MA7. Associated chromosomal aberration :
+MA7:
+  required: False
+  nullable: True
+  type: string
+# ! MA14. Associated balancer :
+MA14:
+  required: False
+  nullable: True
+  type: string
+# ! MA12. Consequent allele(s) :
+MA12:
+  required: False
+  nullable: True
+  type: [list, string]
+# ! MA8. Phenotype (viable, fertile) :
+MA8:
+  required: False
+  nullable: True
+  type: [list, string]
+# ! MA21a. Genomic location of insertion :
+MA21a:
+  required: False
+  nullable: True
+  type: string
+# ! MA21b. Genome release number for entry in MA21a :
+MA21b:
+  required: False
+  nullable: True
+  type: string
+# ! MA21e. Comments concerning genomic location :
+MA21e:
+  required: False
+  nullable: True
+  type: string
+# ! MA6. Orientation of insert relative to chromosome :
+MA6:
+  required: False
+  nullable: True
+  type: string
+# ! MA21c. Insertion into natTE (identified, in FB) :
+MA21c:
+  required: False
+  nullable: True
+  type: string
+# ! MA21f. Insertion into other TE or repeat region (“y”/blank) :
+MA21f:
+  required: False
+  nullable: True
+  type: string
+# ! MA21d. Distance from insertion site to end of natTE/repeat :
+MA21d:
+  required: False
+  nullable: True
+  type: string
+# ! MA19a. Accession for insertion flanking sequence (dupl for multiple) :
+MA19a:
+  required: False
+  nullable: True
+  type: string
+# ! MA19b. Insertion site accession type (5’, 3’, b) :
+MA19b:
+  required: False
+  nullable: True
+  type: string
+# ! MA19c. Position of first base of target sequence in accession :
+MA19c:
+  required: False
+  nullable: True
+  type: string
+# ! MA19d. First base of unique sequence in accession if in natTE :
+MA19d:
+  required: False
+  nullable: True
+  type: string
+# ! MA19e. Accession invalidation or assessment :
+MA19e:
+  required: False
+  nullable: True
+  type: string
+# ! MA26. Accession for this instance of natTE :
+MA26:
+  required: False
+  nullable: True
+  type: string
+# ! MA23a. Insertion-affected gene reported (dupl for multiple) :
+MA23a:
+  required: False
+  nullable: True
+  type: string
+# ! MA23b. Affected gene criteria [CV] :
+MA23b:
+  required: False
+  nullable: True
+  type: string
+# ! MA23c. Comment, affected gene criteria [free text] :
+MA23c:
+  required: False
+  nullable: True
+  type: string
+# ! MA23g. Orientation relative to affected gene :
+MA23g:
+  required: False
+  nullable: True
+  type: string
+# ! MA15a. FBti progenitor (via transposition) at distinct location :
+MA15a:
+  required: False
+  nullable: True
+  type: string
+# ! MA15b. FBti progenitor (via recombination) at distinct location :
+MA15b:
+  required: False
+  nullable: True
+  type: string
+# ! MA15c. Replaced FBti progenitor, recombination substrate :
+MA15c:
+  required: False
+  nullable: True
+  type: string
+# ! MA15d. Modified FBti progenitor (in situ) :
+MA15d:
+  required: False
+  nullable: True
+  type: [list, string]
+# ! MA24. Arose in multiple insertion line (“y”/“p”/blank) :
+MA24:
+  required: False
+  nullable: True
+  type: string
+# ! MA18. Co-isolated insertion(s) :
+MA18:
+  required: False
+  nullable: True
+  type: [list, string]
+# ! MA9. Comments [free text] :
+MA9:
+  required: False
+  nullable: True
+  type: [list, string]
+# ! MA16. Information on availability :
+MA16:
+  required: False
+  nullable: True
+  type: [list, string]
+# ! MA30. From dataset/collection (symbol) :
+MA30:
+  required: False
+  nullable: True
+  type: string
+# ! MA30a. Type of relationship to dataset/collection [member_of_reagent_collection/experimental_result] :
+MA30a:
+  required: False
+  nullable: True
+  type: string
+# ! MA10. Internal notes :
+MA10:
+  required: False
+  nullable: True
+  type: [list, string]


### PR DESCRIPTION
Allow "fake parsing" of transposon proforma. Error message is given to warn that it is not coded yet but no longer crashing and stopping further processing. New no_flag for P41. Fake GA35 in alleles for now, not coded and an error is produced if set, it just no longer crashes the system.